### PR TITLE
[TFB-107] - fix deploy: clean untracked files before checkout to prevent overwrite error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,9 +62,9 @@ jobs:
 
             cd "$TARGET_DIR"
             git fetch --all --prune
+            git clean -ffd -e '.env' -e 'uploads/'
             git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"
             git reset --hard "origin/${{ github.ref_name }}"
-            git clean -fd
 
             if [ ! -f .env ]; then
               echo "Missing $TARGET_DIR/.env"


### PR DESCRIPTION
## Summary

- Moves `git clean -ffd` **before** `git checkout -B` so untracked files on the VPS are removed before git tries to check them out
- Excludes `.env` and `uploads/` from clean to preserve secrets and uploaded images
- Root cause: VPS prod directory had all project files sitting as untracked (copied manually or left from a previous deploy method), causing `checkout` to abort with "untracked files would be overwritten"

## Why not `git reset --hard HEAD` first?
That still fails with `fatal: ambiguous argument 'HEAD'` when no branch has ever been checked out — which is the same root cause as the previous fix.

## Test plan
- [ ] Merge to `main` and verify the Actions deploy run passes