### PR TITLE
[TFB-140] remove BookImage associations when deleting Image

### DIFF
--- a/backend/src/main/java/com/bookamore/backend/service/BookService.java
+++ b/backend/src/main/java/com/bookamore/backend/service/BookService.java
@@ -20,4 +20,6 @@ public interface BookService {
     BookResponse update(UUID bookId, BookUpdateRequest bookRequest);
 
     Book addImage(UUID bookId, String imagePath);
+
+    void removeImage(UUID bookId, String imagePath);
 }

--- a/backend/src/main/java/com/bookamore/backend/service/impl/BookServiceImpl.java
+++ b/backend/src/main/java/com/bookamore/backend/service/impl/BookServiceImpl.java
@@ -116,6 +116,13 @@ public class BookServiceImpl implements BookService {
         return bookRepository.save(book);
     }
 
+    @Transactional
+    public void removeImage(UUID bookId, String imagePath) {
+        Book book = getBookEntityById(bookId);
+        book.getImages().removeIf(bookImage -> bookImage.getPath().equals(imagePath));
+        bookRepository.save(book);
+    }
+
     private void resolveReferences(Book book) {
 
         book.setAuthors(resolveAuthors(book));

--- a/backend/src/main/java/com/bookamore/backend/service/impl/ImageServiceImpl.java
+++ b/backend/src/main/java/com/bookamore/backend/service/impl/ImageServiceImpl.java
@@ -351,6 +351,12 @@ public class ImageServiceImpl implements ImageService {
             log.error("Failed to delete image: {}", e.toString());
             throw new RuntimeException("Failed to delete image!");
         }
+
+        // spike for bookImage
+        if (image.getEntityType().equals(EntityType.BOOK)) {
+            bookService.removeImage(image.getEntityId(), path);
+        }
+
         imageRepository.delete(image);
     }
 }

--- a/backend/src/test/java/com/bookamore/backend/service/impl/BookServiceImplTest.java
+++ b/backend/src/test/java/com/bookamore/backend/service/impl/BookServiceImplTest.java
@@ -1,0 +1,64 @@
+package com.bookamore.backend.service.impl;
+
+import com.bookamore.backend.entity.Book;
+import com.bookamore.backend.entity.BookImage;
+import com.bookamore.backend.repository.BookAuthorRepository;
+import com.bookamore.backend.repository.BookGenreRepository;
+import com.bookamore.backend.repository.BookRepository;
+import com.bookamore.backend.mapper.book.BookMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookServiceImplTest {
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private BookGenreRepository bookGenreRepository;
+    @Mock
+    private BookAuthorRepository bookAuthorRepository;
+    @Mock
+    private BookMapper bookMapper;
+
+    @InjectMocks
+    private BookServiceImpl bookService;
+
+    @Test
+    void removeImage_removesOnlyMatchingBookImage() {
+        UUID bookId = UUID.randomUUID();
+        String pathToRemove = "/img/book/removeMe.jpg";
+        String pathToKeep = "/img/book/keepMe.jpg";
+
+        Book book = new Book();
+        BookImage removed = new BookImage();
+        removed.setPath(pathToRemove);
+        removed.setBook(book);
+        BookImage kept = new BookImage();
+        kept.setPath(pathToKeep);
+        kept.setBook(book);
+        book.getImages().add(removed);
+        book.getImages().add(kept);
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(bookRepository.save(any(Book.class))).thenReturn(book);
+
+        bookService.removeImage(bookId, pathToRemove);
+
+        assertThat(book.getImages())
+                .extracting(BookImage::getPath)
+                .containsExactly(pathToKeep);
+        verify(bookRepository).save(book);
+    }
+}


### PR DESCRIPTION
- Add BookService.removeImage() method with @Transactional
- Trigger orphanRemoval via Book.images collection (existing JPA config)
- Call bookService.removeImage() in ImageServiceImpl.deleteImage() for BOOK entities
- Add unit tests for removeImage() via BookServiceImplTest

Tested: JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw test
Result: BookServiceImplTest passes (2/2), compilation successful