### PR TITLE
fix(ci): align dev APP_NAME with docker-compose.dev.yml name: pin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
               BE_PORT="3001"
               DB_PORT="5433"
               DB_NAME="bookamore_dev"
-              APP_NAME="dev_bookamore"
+              APP_NAME="bookamore_dev"
               SPRING_PROFILES_ACTIVE="dev"
               UPLOADS_DIR="$TARGET_DIR/uploads"
               CLIENT_URL="https://bookamore-dev.alt-web.biz.ua"


### PR DESCRIPTION
CI passed -p dev_bookamore, file pins name: bookamore_dev — CLI -p wins, causing container name conflict with pre-existing bookamore_dev_db. Same root cause as prod #123, now fixed for dev.