### PR TITLE
[TFB-141] Tolerate deleted parent book during image delete

### DIFF
--- a/backend/src/main/java/com/bookamore/backend/service/impl/ImageServiceImpl.java
+++ b/backend/src/main/java/com/bookamore/backend/service/impl/ImageServiceImpl.java
@@ -333,7 +333,16 @@ public class ImageServiceImpl implements ImageService {
         //    can never roll back the transaction and leave orphaned images/books_images rows.
         // spike for bookImage
         if (image.getEntityType().equals(EntityType.BOOK)) {
-            bookService.removeImage(image.getEntityId(), path);
+            // The parent book may already be gone (orphaned image whose entity_id points to a
+            // deleted book). Guard with existsById instead of catching the exception: letting
+            // ResourceNotFoundException cross removeImage()'s @Transactional boundary would mark
+            // the shared transaction rollback-only and abort the whole delete (UnexpectedRollback).
+            if (bookRepository.existsById(image.getEntityId())) {
+                bookService.removeImage(image.getEntityId(), path);
+            } else {
+                log.warn("Parent book {} no longer exists for image {}; skipping association cleanup, "
+                        + "deleting image record only.", image.getEntityId(), imageId);
+            }
         }
         imageRepository.delete(image);
 

--- a/backend/src/test/java/com/bookamore/backend/service/impl/ImageServiceImplTest.java
+++ b/backend/src/test/java/com/bookamore/backend/service/impl/ImageServiceImplTest.java
@@ -2,6 +2,7 @@ package com.bookamore.backend.service.impl;
 
 import com.bookamore.backend.entity.Image;
 import com.bookamore.backend.entity.enums.EntityType;
+import com.bookamore.backend.repository.BookRepository;
 import com.bookamore.backend.repository.ImageRepository;
 import com.bookamore.backend.repository.ImageStorageRepository;
 import com.bookamore.backend.service.BookService;
@@ -16,6 +17,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +29,8 @@ class ImageServiceImplTest {
     private ImageRepository imageRepository;
     @Mock
     private ImageStorageRepository imageLocalStorageRepository;
+    @Mock
+    private BookRepository bookRepository;
     @Mock
     private BookService bookService;
 
@@ -49,6 +54,7 @@ class ImageServiceImplTest {
         image.setEntityId(bookId);
 
         when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+        when(bookRepository.existsById(bookId)).thenReturn(true);
         // deleteIfExists() semantics: file already absent -> returns false, no exception
         when(imageLocalStorageRepository.deleteImage("missing.jpg", "book")).thenReturn(false);
 
@@ -75,12 +81,40 @@ class ImageServiceImplTest {
         image.setEntityId(bookId);
 
         when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+        when(bookRepository.existsById(bookId)).thenReturn(true);
         when(imageLocalStorageRepository.deleteImage("broken.jpg", "book"))
                 .thenThrow(new IOException("disk error"));
 
         assertThatCode(() -> imageService.deleteImage(imageId)).doesNotThrowAnyException();
 
         verify(bookService).removeImage(bookId, path);
+        verify(imageRepository).delete(image);
+    }
+
+    /**
+     * Orphaned image: entity_id points to a book that was already deleted. The association
+     * cleanup must be skipped (never call removeImage, which would poison the transaction),
+     * and the images record must still be removed so the dead row can be cleaned up.
+     */
+    @Test
+    void deleteImage_whenParentBookMissing_skipsAssociationAndStillDeletesImageRecord() throws IOException {
+        UUID imageId = UUID.randomUUID();
+        UUID missingBookId = UUID.randomUUID();
+        String path = "/img/book/orphan.jpg";
+
+        Image image = new Image();
+        image.setId(imageId);
+        image.setPath(path);
+        image.setEntityType(EntityType.BOOK);
+        image.setEntityId(missingBookId);
+
+        when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+        when(bookRepository.existsById(missingBookId)).thenReturn(false);
+        when(imageLocalStorageRepository.deleteImage("orphan.jpg", "book")).thenReturn(false);
+
+        assertThatCode(() -> imageService.deleteImage(imageId)).doesNotThrowAnyException();
+
+        verify(bookService, never()).removeImage(any(), any());
         verify(imageRepository).delete(image);
     }
 }


### PR DESCRIPTION
## Root cause (deeper than initial fix)

Первісний фікс (try/catch на ResourceNotFoundException навколо bookService.removeImage()) не спрацював у live-тесті: 500 "Transaction silently rolled back because it has been marked as rollback-only".

Причина: bookService.removeImage() має @Transactional(REQUIRED), приєднується до транзакції deleteImage(). Коли exception перетинає межу проксі removeImage(), Spring позначає СПІЛЬНУ транзакцію rollback-only. Перехоплення exception у зовнішньому методі не рятує — на commit летить UnexpectedRollbackException, і imageRepository.delete() теж відкочується.

## Fix

Guard ПЕРЕД входом у exception-шлях замість try/catch:
```java
if (bookRepository.existsById(image.getEntityId())) {
    bookService.removeImage(image.getEntityId(), path);
} else {
    log.warn("Parent book {} no longer exists, deleting image record only.", image.getEntityId());
}
imageRepository.delete(image);
```

## Verification on dev VPS (real HTTP + DB checks)

| Сценарій | HTTP | БД |
|---|---|---|
| Осиротіле зображення (книга видалена) | 204 | images −1→0, WARN, без rollback |
| Нормальне зображення (книга існує) | 204 | images та books_images обидва →0 |

Unit-тести: ImageServiceImplTest 3/3 (відсутній файл; I/O error; відсутня книга). BUILD SUCCESS.

Тестові акаунти прибрані з dev після верифікації.

Ця гілка стекнута на sync/dev-from-main + fix/TFB-141-image-upload-and-delete-dev + backfill script — притягне все відразу.