### PR TITLE
[TFB-142] - add automated VPS backup to Google Drive

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,65 @@
+name: VPS Backup to Google Drive
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # ~03:00 Kyiv
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vps-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set backup date
+        run: echo "DATE=$(date -u +%F)" >> "$GITHUB_ENV"
+
+      - name: Install SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
+
+      - name: Trust VPS host key
+        run: ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Dump DBs and archive VPS state
+        run: |
+          ssh "devuser@${{ secrets.VPS_HOST }}" "DATE=${{ env.DATE }} bash -s" <<'EOF'
+          set -euo pipefail
+          STAGE="/tmp/vps_backup_$DATE"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE/db" "$STAGE/nginx"
+
+          docker exec bookamore-prod-db-1 sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > "$STAGE/db/prod_$DATE.sql"
+          docker exec bookamore_dev_db sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > "$STAGE/db/dev_$DATE.sql"
+
+          cp /etc/nginx/nginx.conf "$STAGE/nginx/nginx.conf"
+
+          tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
+              -czf "$STAGE/devuser_www.tar.gz" -C /home/devuser www
+          tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
+              -czf "$STAGE/deploy_www.tar.gz" -C /home/deploy www
+
+          tar -czf "/tmp/full_vps_backup_$DATE.tar.gz" -C /tmp "vps_backup_$DATE"
+          rm -rf "$STAGE"
+          EOF
+
+      - name: Fetch archive from VPS
+        run: |
+          scp "devuser@${{ secrets.VPS_HOST }}:/tmp/full_vps_backup_${{ env.DATE }}.tar.gz" "./full_vps_backup_${{ env.DATE }}.tar.gz"
+          ssh "devuser@${{ secrets.VPS_HOST }}" "rm -f /tmp/full_vps_backup_${{ env.DATE }}.tar.gz"
+
+      - name: Verify archive size
+        run: ls -lh "full_vps_backup_${{ env.DATE }}.tar.gz"
+
+      - name: Upload archive to Google Drive
+        uses: wei/rclone@v1
+        env:
+          RCLONE_CONF: ${{ secrets.RCLONE_CONF }}
+        with:
+          args: copy "full_vps_backup_${{ env.DATE }}.tar.gz" "gdrive:${{ secrets.GDRIVE_FOLDER_ID }}"


### PR DESCRIPTION
## Summary
- Daily GH Actions job (+ manual workflow_dispatch) dumps prod/dev Postgres DBs and archives `/home/devuser/www`, `/home/deploy/www`, `/etc/nginx/nginx.conf` from the VPS
- Uploads the resulting tarball via rclone (service account) to the shared Google Drive backups folder
- Prep step for TFB-142 (Clear VPS / redeploy environments from scratch)

## Test plan
- [ ] Merge and manually trigger via `gh workflow run backup.yml --ref dev`
- [ ] Confirm archive appears in Google Drive backups folder
- [ ] Confirm DB dumps are non-empty and restorable