### PR TITLE
[TFB-142] - pin rclone remote root to Bookamore_backups folder

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -62,4 +62,5 @@ jobs:
         env:
           RCLONE_CONF: ${{ secrets.RCLONE_CONF }}
         with:
-          args: copy "full_vps_backup_${{ env.DATE }}.tar.gz" "gdrive:${{ secrets.GDRIVE_FOLDER_ID }}"
+          # gdrive: root is pinned to the backups folder via root_folder_id in RCLONE_CONF
+          args: copy "full_vps_backup_${{ env.DATE }}.tar.gz" "gdrive:"


### PR DESCRIPTION
## Summary
- First backup run created a stray subfolder inside Bookamore_backups instead of writing directly into it, because the rclone remote had no `root_folder_id` and the destination path used the folder ID as a literal path segment.
- Fixed by pinning `root_folder_id` in `RCLONE_CONF` to the Bookamore_backups folder and simplifying the workflow destination to `gdrive:`.
- Manually cleaned up the stray folder/misplaced file on Drive already.

## Test plan
- [ ] Trigger `workflow_dispatch` after merge, confirm the archive lands directly in Bookamore_backups with no extra folder