### PR TITLE
move deploy target to /home/deploy/www, backup letsencrypt certs, update docs

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -40,6 +40,9 @@ jobs:
 
           cp /etc/nginx/nginx.conf "$STAGE/nginx/nginx.conf"
 
+          sudo -n /usr/local/sbin/backup-letsencrypt.sh
+          mv /tmp/letsencrypt_backup.tar.gz "$STAGE/letsencrypt.tar.gz"
+
           tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
               -czf "$STAGE/devuser_www.tar.gz" -C /home/devuser www
           tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -62,4 +62,5 @@ jobs:
         env:
           RCLONE_CONF: ${{ secrets.RCLONE_CONF }}
         with:
-          args: copy "full_vps_backup_${{ env.DATE }}.tar.gz" "gdrive:${{ secrets.GDRIVE_FOLDER_ID }}"
+          # gdrive: root is pinned to the backups folder via root_folder_id in RCLONE_CONF
+          args: copy "full_vps_backup_${{ env.DATE }}.tar.gz" "gdrive:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,8 @@ jobs:
           script: |
             set -euo pipefail
 
-            TARGET_DIR_PROD="/home/devuser/www/prod"
-            TARGET_DIR_DEV="/home/devuser/www/dev"
+            TARGET_DIR_PROD="/home/deploy/www/prod"
+            TARGET_DIR_DEV="/home/deploy/www/dev"
 
             if [ "${{ github.ref_name }}" = "main" ]; then
               TARGET_DIR="$TARGET_DIR_PROD"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,8 +1,8 @@
 # Bookamore — VPS Deployment Guide
 
-> Dual-environment setup on `185.143.145.151`  
-> **Prod**: `bookamore.alt-web.biz.ua` → port `3432`  
-> **Dev**: `bookamore-dev.alt-web.biz.ua` → port `3433`
+> Dual-environment setup:
+> - **Prod**: [http://bookamore.alt-web.biz.ua/](http://bookamore.alt-web.biz.ua/) — deployed on push to `main`
+> - **Dev**: [http://bookamore-dev.alt-web.biz.ua/](http://bookamore-dev.alt-web.biz.ua/) — deployed on push to `dev`
 
 ---
 
@@ -12,11 +12,11 @@ Go to **GitHub → Repository → Settings → Secrets and variables → Actions
 
 | Secret name   | Description                                                            | Example value                          |
 |--------------|------------------------------------------------------------------------|----------------------------------------|
-| `VPS_HOST`   | Public IP or hostname of the VPS                                       | `185.143.145.151`                      |
+| `VPS_HOST`   | Hostname of the VPS (kept as a secret, not published here)             | `<vps-host>`                           |
 | `VPS_SSH_KEY`| Private key whose public key is in `/home/devuser/.ssh/authorized_keys` | `-----BEGIN OPENSSH PRIVATE KEY-----…` |
 
 > **Note:** App credentials (`DB_USER`, `DB_PASSWORD`, JWT, OAuth keys) are read from
-> `/home/devuser/www/dev/.env` and `/home/devuser/www/prod/.env` on the VPS.
+> `/home/deploy/www/dev/.env` and `/home/deploy/www/prod/.env` on the VPS.
 > They are not required as GitHub Secrets in this workflow.
 
 ---
@@ -60,10 +60,14 @@ cat ~/.ssh/bookamore_deploy
 ### 2.3 Create deployment directories
 
 ```bash
-sudo mkdir -p /home/devuser/www/prod
-sudo mkdir -p /home/devuser/www/dev
-sudo chown -R devuser:devuser /home/devuser/www
+sudo mkdir -p /home/deploy/www/prod
+sudo mkdir -p /home/deploy/www/dev
+sudo chown -R deploy:deploy /home/deploy/www
+sudo chmod -R g+rwX /home/deploy/www
+sudo usermod -aG deploy devuser
 ```
+
+The CI workflow logs in as `devuser` and writes into `/home/deploy/www` via `deploy` group membership — `devuser` never needs its own SSH key on `deploy`.
 
 ### 2.4 Create `.env` files for each environment
 
@@ -72,14 +76,14 @@ The CI workflow expects `.env` to already exist in each target directory. Create
 
 ```bash
 # Dev environment
-cp /path/to/repo/.env.example /home/devuser/www/dev/.env
-nano /home/devuser/www/dev/.env
+cp /path/to/repo/.env.example /home/deploy/www/dev/.env
+nano /home/deploy/www/dev/.env
 ```
 
 ```bash
 # Prod environment
-cp /path/to/repo/.env.example /home/devuser/www/prod/.env
-nano /home/devuser/www/prod/.env
+cp /path/to/repo/.env.example /home/deploy/www/prod/.env
+nano /home/deploy/www/prod/.env
 ```
 
 Fill in the sensitive values (`DB_PASSWORD`, `JWT_SECRET`, OAuth credentials) and update
@@ -93,7 +97,7 @@ the infrastructure values to match each environment:
 | `DB_PORT`              | `5433`                                  | `5432`                               |
 | `DB_NAME`              | `bookamore_dev`                         | `bookamore_prod`                     |
 | `SPRING_PROFILES_ACTIVE` | `dev`                                 | `prod`                               |
-| `UPLOADS_DIR`          | `/home/devuser/www/dev/uploads`         | `/home/devuser/www/prod/uploads`     |
+| `UPLOADS_DIR`          | `/home/deploy/www/dev/uploads`          | `/home/deploy/www/prod/uploads`      |
 | `CLIENT_URL`           | `https://bookamore-dev.alt-web.biz.ua`  | `https://bookamore.alt-web.biz.ua`   |
 
 > The workflow keeps env-specific routing values synchronized (`APP_NAME`, ports, profile, `CLIENT_URL`),
@@ -104,8 +108,8 @@ the infrastructure values to match each environment:
 The deploy workflow updates an existing checkout in each target directory. Initialize both once:
 
 ```bash
-sudo -u devuser git clone <YOUR_REPO_SSH_OR_HTTPS_URL> /home/devuser/www/prod
-sudo -u devuser git clone <YOUR_REPO_SSH_OR_HTTPS_URL> /home/devuser/www/dev
+sudo -u devuser git clone <YOUR_REPO_SSH_OR_HTTPS_URL> /home/deploy/www/prod
+sudo -u devuser git clone <YOUR_REPO_SSH_OR_HTTPS_URL> /home/deploy/www/dev
 ```
 
 ---
@@ -185,14 +189,17 @@ sudo systemctl status certbot.timer
 
 After the one-time VPS setup is complete, every deploy is fully automatic:
 
-| Git push to… | Environment | Frontend port | Backend port |
-|--------------|-------------|---------------|--------------|
-| `main`       | Production  | `3432`        | `3000`       |
-| `dev`        | Development | `3433`        | `3001`       |
+| Git push to… | Environment | URL                                                                    | Frontend port | Backend port |
+|--------------|-------------|-------------------------------------------------------------------------|---------------|--------------|
+| `main`       | Production  | [http://bookamore.alt-web.biz.ua/](http://bookamore.alt-web.biz.ua/)         | `3432`        | `3000`       |
+| `dev`        | Development | [http://bookamore-dev.alt-web.biz.ua/](http://bookamore-dev.alt-web.biz.ua/) | `3433`        | `3001`       |
+
+- The **dev environment** is deployed on every push to the `dev` branch.
+- The **prod environment** is deployed on every push to the `main` branch.
 
 The GitHub Actions workflow:
-1. SSHs into the VPS.
-2. Uses `/home/devuser/www/prod` for `main` and `/home/devuser/www/dev` for `dev`.
+1. SSHs into the VPS as `devuser`.
+2. Uses `/home/deploy/www/prod` for `main` and `/home/deploy/www/dev` for `dev`.
 3. Syncs non-sensitive env routing values in `.env`.
 4. Runs `docker compose -f docker-compose.yaml --env-file .env up -d --build` (prod) or `docker compose -f docker-compose.dev.yml --env-file .env up -d --build` (dev).
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,8 +25,7 @@ services:
       - FACEBOOK_CLIENT_SECRET=${FACEBOOK_CLIENT_SECRET}
     volumes:
       - ./.env:/app/.env
-      # Використовуємо абсолютний шлях для монтування папки з фото
-      - /home/devuser/www/dev/uploads:/app/uploads
+      - ${UPLOADS_DIR}:/app/uploads
     depends_on:
       - db
 
@@ -39,8 +38,7 @@ services:
     ports:
       - "127.0.0.1:${FE_PORT}:80"
     volumes:
-      # Монтуємо ту саму папку, щоб Nginx бачив завантажені фото
-      - /home/devuser/www/dev/uploads:/usr/share/nginx/html/uploads:ro
+      - ${UPLOADS_DIR}:/usr/share/nginx/html/uploads:ro
     depends_on:
       - backend
 

--- a/frontend/src/app/store/api/BooksApi.ts
+++ b/frontend/src/app/store/api/BooksApi.ts
@@ -1,5 +1,8 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { extractImagePaths } from '@shared/helpers/extractImagePaths';
 import type { Book, BookPatchRequest } from '@/types/entities/Book';
+
+type RawBook = Omit<Book, 'images'> & { images: Parameters<typeof extractImagePaths>[0] };
 
 export const BooksApi = createApi({
   reducerPath: 'booksApi',
@@ -9,6 +12,10 @@ export const BooksApi = createApi({
   endpoints: (build) => ({
     getBookById: build.query<Book, number | string>({
       query: (id) => `/${id}`,
+      transformResponse: (response: RawBook): Book => ({
+        ...response,
+        images: extractImagePaths(response.images),
+      }),
     }),
     updateBookById: build.mutation<Book, BookPatchRequest>({
       query: (bookPatchRequest) => ({

--- a/frontend/src/app/store/api/OffersApi.ts
+++ b/frontend/src/app/store/api/OffersApi.ts
@@ -1,5 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { convertObjectToSearchParams } from '@app/store/helpers/convertToSearchParams.ts';
+import { extractImagePaths } from '@shared/helpers/extractImagePaths';
 
 import type { ListResponse } from '@/types/entities/ListResponse';
 import type {
@@ -13,6 +14,17 @@ import type {
 } from '@/types/entities/OfferWithBook';
 import type { QueryParams } from '@/types/entities/QueryParams';
 import type { RootState } from '../store';
+
+type RawOfferWithBook = Omit<OfferWithBook, 'book'> & {
+  book: Omit<OfferWithBook['book'], 'images'> & {
+    images: Parameters<typeof extractImagePaths>[0];
+  };
+};
+
+const normalizeOfferWithBook = (offer: RawOfferWithBook): OfferWithBook => ({
+  ...offer,
+  book: { ...offer.book, images: extractImagePaths(offer.book.images) },
+});
 
 export const OffersApi = createApi({
   reducerPath: 'offerApi',
@@ -45,9 +57,14 @@ export const OffersApi = createApi({
       query: (params) => {
         return `/with-book?${params ? convertObjectToSearchParams(params) : ''}`;
       },
+      transformResponse: (response: ListResponse<RawOfferWithBook>) => ({
+        ...response,
+        content: response.content.map(normalizeOfferWithBook),
+      }),
     }),
     getOfferWithBookById: build.query<OfferWithBook, string>({
       query: (id) => `/with-book/${id}`,
+      transformResponse: normalizeOfferWithBook,
     }),
     addOfferWithBook: build.mutation<OfferWithBook, OfferWithBookRequest>({
       query: (newOffer) => ({
@@ -55,6 +72,7 @@ export const OffersApi = createApi({
         method: 'POST',
         body: newOffer,
       }),
+      transformResponse: normalizeOfferWithBook,
     }),
     addOffer: build.mutation<Offer, OfferRequest>({
       query: (newOffer) => ({

--- a/frontend/src/shared/helpers/extractImagePaths.ts
+++ b/frontend/src/shared/helpers/extractImagePaths.ts
@@ -1,0 +1,4 @@
+type RawImage = { id: string; path: string };
+
+export const extractImagePaths = (images: RawImage[] | undefined): string[] =>
+  images?.map((image) => image.path) ?? [];


### PR DESCRIPTION
Summary
deploy.yml: deploy target directories switched from /home/devuser/www/{prod,dev} to /home/deploy/www/{prod,dev}. SSH login stays devuser (no separate deploy key exists or is planned) — write access comes from devuser's deploy group membership.
/home/devuser/www/{prod,dev} were rsynced into /home/deploy/www/{prod,dev} on the VPS ahead of this change (verified clean diff, .env/.git present).
backup.yml: now also archives the real Let's Encrypt certs from /etc/letsencrypt via a narrowly-scoped NOPASSWD sudo rule (/usr/local/sbin/backup-letsencrypt.sh, exact-match only).
deploy/README.md: removed the VPS IP from docs, replaced with the public domains; updated all /home/devuser/www path references to /home/deploy/www.
Test plan
 After merge, trigger workflow_dispatch on backup.yml, confirm the archive includes letsencrypt.tar.gz
 Confirm next deploy to dev picks up /home/deploy/www/dev correctly and the site stays up
 Confirm next deploy to main picks up /home/deploy/www/prod correctly and the site stays up