### PR TITLE
[TFB-154] - normalize book image objects to path strings

### DIFF
--- a/frontend/src/app/store/api/BooksApi.ts
+++ b/frontend/src/app/store/api/BooksApi.ts
@@ -1,5 +1,8 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { extractImagePaths } from '@shared/helpers/extractImagePaths';
 import type { Book, BookPatchRequest } from '@/types/entities/Book';
+
+type RawBook = Omit<Book, 'images'> & { images: Parameters<typeof extractImagePaths>[0] };
 
 export const BooksApi = createApi({
   reducerPath: 'booksApi',
@@ -9,6 +12,10 @@ export const BooksApi = createApi({
   endpoints: (build) => ({
     getBookById: build.query<Book, number | string>({
       query: (id) => `/${id}`,
+      transformResponse: (response: RawBook): Book => ({
+        ...response,
+        images: extractImagePaths(response.images),
+      }),
     }),
     updateBookById: build.mutation<Book, BookPatchRequest>({
       query: (bookPatchRequest) => ({

--- a/frontend/src/app/store/api/OffersApi.ts
+++ b/frontend/src/app/store/api/OffersApi.ts
@@ -1,5 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { convertObjectToSearchParams } from '@app/store/helpers/convertToSearchParams.ts';
+import { extractImagePaths } from '@shared/helpers/extractImagePaths';
 
 import type { ListResponse } from '@/types/entities/ListResponse';
 import type {
@@ -13,6 +14,17 @@ import type {
 } from '@/types/entities/OfferWithBook';
 import type { QueryParams } from '@/types/entities/QueryParams';
 import type { RootState } from '../store';
+
+type RawOfferWithBook = Omit<OfferWithBook, 'book'> & {
+  book: Omit<OfferWithBook['book'], 'images'> & {
+    images: Parameters<typeof extractImagePaths>[0];
+  };
+};
+
+const normalizeOfferWithBook = (offer: RawOfferWithBook): OfferWithBook => ({
+  ...offer,
+  book: { ...offer.book, images: extractImagePaths(offer.book.images) },
+});
 
 export const OffersApi = createApi({
   reducerPath: 'offerApi',
@@ -45,9 +57,14 @@ export const OffersApi = createApi({
       query: (params) => {
         return `/with-book?${params ? convertObjectToSearchParams(params) : ''}`;
       },
+      transformResponse: (response: ListResponse<RawOfferWithBook>) => ({
+        ...response,
+        content: response.content.map(normalizeOfferWithBook),
+      }),
     }),
     getOfferWithBookById: build.query<OfferWithBook, string>({
       query: (id) => `/with-book/${id}`,
+      transformResponse: normalizeOfferWithBook,
     }),
     addOfferWithBook: build.mutation<OfferWithBook, OfferWithBookRequest>({
       query: (newOffer) => ({
@@ -55,6 +72,7 @@ export const OffersApi = createApi({
         method: 'POST',
         body: newOffer,
       }),
+      transformResponse: normalizeOfferWithBook,
     }),
     addOffer: build.mutation<Offer, OfferRequest>({
       query: (newOffer) => ({

--- a/frontend/src/shared/helpers/extractImagePaths.ts
+++ b/frontend/src/shared/helpers/extractImagePaths.ts
@@ -1,0 +1,4 @@
+type RawImage = { id: string; path: string };
+
+export const extractImagePaths = (images: RawImage[] | undefined): string[] =>
+  images?.map((image) => image.path) ?? [];


### PR DESCRIPTION
## Summary
- Backend `BookResponse.images` has been `List<ImageShortResponse>` (`{id, path}`) since the UUID migration back in January, but the frontend `Book` type still declares `images: string[]` and renders `book.images[0]` directly as an `<img src>` — producing `[object Object]` and a broken image icon for every book/offer card.
- Verified server-side is fully healthy: nginx `/img/` alias, uploaded files, and the API response all check out — this is purely a frontend/backend contract mismatch, unrelated to the ongoing TFB-142 VPS work.
- Added `extractImagePaths` helper and wired `transformResponse` in `BooksApi.ts` and `OffersApi.ts` so `images` is normalized to `string[]` at the API boundary, matching the existing `Book` type used everywhere downstream.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] After deploy, confirm book covers render on bookamore-dev.alt-web.biz.ua homepage and offer detail pages