### PR TITLE
[TFB-142] - use UPLOADS_DIR env var for dev uploads volume instead of hardcoded devuser path

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,8 +25,7 @@ services:
       - FACEBOOK_CLIENT_SECRET=${FACEBOOK_CLIENT_SECRET}
     volumes:
       - ./.env:/app/.env
-      # Використовуємо абсолютний шлях для монтування папки з фото
-      - /home/devuser/www/dev/uploads:/app/uploads
+      - ${UPLOADS_DIR}:/app/uploads
     depends_on:
       - db
 
@@ -39,8 +38,7 @@ services:
     ports:
       - "127.0.0.1:${FE_PORT}:80"
     volumes:
-      # Монтуємо ту саму папку, щоб Nginx бачив завантажені фото
-      - /home/devuser/www/dev/uploads:/usr/share/nginx/html/uploads:ro
+      - ${UPLOADS_DIR}:/usr/share/nginx/html/uploads:ro
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- `docker-compose.dev.yml` had the uploads bind mount hardcoded to `/home/devuser/www/dev/uploads`, while `docker-compose.yaml` (prod) already used `${UPLOADS_DIR}` dynamically from `deploy.yml`.
- After the TFB-142 deploy target migration to `/home/deploy/www`, the hardcoded dev path would silently keep writing new uploads to the old, soon-to-be-removed `/home/devuser` tree.
- Switched both dev volumes to `${UPLOADS_DIR}`, matching the prod convention. `deploy.yml` already sets `UPLOADS_DIR="$TARGET_DIR/uploads"` for both branches.
- Verified no drift between `/home/devuser/www/{dev,prod}/uploads` and `/home/deploy/www/{dev,prod}/uploads` before this change (dry-run rsync clean).

## Test plan
- [x] YAML syntax valid
- [ ] After merge + deploy, confirm dev backend/frontend mount `/home/deploy/www/dev/uploads`