### PR TITLE
[TFB-142] - stop backing up /home/devuser/www (retired, superseded by /home/deploy/www)

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -44,8 +44,6 @@ jobs:
           mv /tmp/letsencrypt_backup.tar.gz "$STAGE/letsencrypt.tar.gz"
 
           tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
-              -czf "$STAGE/devuser_www.tar.gz" -C /home/devuser www
-          tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
               -czf "$STAGE/deploy_www.tar.gz" -C /home/deploy www
 
           tar -czf "/tmp/full_vps_backup_$DATE.tar.gz" -C /tmp "vps_backup_$DATE"


### PR DESCRIPTION
## Summary
- `/home/devuser/www/{prod,dev}` is being retired in favor of `/home/deploy/www/{prod,dev}` (already fully synced and live).
- Removed the `devuser_www.tar.gz` archiving step from `backup.yml` — nothing left to back up there once the directory is deleted.

## Test plan
- [ ] After merge, trigger `workflow_dispatch`, confirm backup still succeeds with just `deploy_www.tar.gz`, DB dumps, nginx.conf, letsencrypt.tar.gz