### PR TITLE
[TFB-142] - sync dev into main (drop devuser backup step)

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -44,8 +44,6 @@ jobs:
           mv /tmp/letsencrypt_backup.tar.gz "$STAGE/letsencrypt.tar.gz"
 
           tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
-              -czf "$STAGE/devuser_www.tar.gz" -C /home/devuser www
-          tar --exclude='.git' --exclude='node_modules' --exclude='target' --exclude='dist' \
               -czf "$STAGE/deploy_www.tar.gz" -C /home/deploy www
 
           tar -czf "/tmp/full_vps_backup_$DATE.tar.gz" -C /tmp "vps_backup_$DATE"


### PR DESCRIPTION
## Summary
- Sync `dev` into `main` to land PR #141 (removes the `devuser_www.tar.gz` backup step, since `/home/devuser/www` is about to be deleted from the VPS).
- `backup.yml`'s schedule/workflow_dispatch triggers read from the default branch (`main`), so this needs to land there before the directory is removed to avoid a failed scheduled run.

## Test plan
- [ ] After merge, trigger `workflow_dispatch` on `backup.yml`, confirm it succeeds without referencing `/home/devuser`