### PR TITLE
[TFB-142] - fix host nginx /img alias paths after move to /home/deploy/www

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -40,9 +40,11 @@ server {
     }
 
     # ОБРОБКА ЗОБРАЖЕНЬ (PROD)
+    # Бекенд пише файли в ${UPLOADS_DIR}/<entity>/<hash>.<ext>,
+    # тому /img/book/x.jpg має мапитись у .../uploads/book/x.jpg
     location /img/ {
-        alias /home/devuser/www/prod/uploads/img/;
-        try_files $uri $uri/ =404;
+        alias /home/deploy/www/prod/uploads/;
+        try_files $uri =404;
         access_log off;
         expires 30d;
         add_header Cache-Control "public";
@@ -67,11 +69,12 @@ server {
         proxy_set_header Host $host;
     }
 
-    location /img/book/ {
-        alias /home/devuser/www/dev/uploads/;
-        try_files $uri $uri/ =404;
+    location /img/ {
+        alias /home/deploy/www/dev/uploads/;
+        try_files $uri =404;
         access_log off;
         expires 30d;
+        add_header Cache-Control "public";
     }
 }
 


### PR DESCRIPTION
## Проблема
Нові завантажені зображення віддавали 404 на dev і prod (`/img/book/<hash>.jpg`).

Референсний конфіг хостового nginx (`deploy/nginx.conf`) містив застарілі шляхи:
- **prod**: `alias /home/devuser/www/prod/uploads/img/` — виведений з експлуатації `devuser`-шлях (TFB-142) + зайвий сегмент `img/`, якого немає на диску;
- **dev**: `location /img/book/` + `alias /home/devuser/www/dev/uploads/` — через семантику `alias` губилась піддиректорія `book/`, куди реально пише бекенд (`ImageServiceImpl` зберігає в `${UPLOADS_DIR}/book/<hash>`).

## Зміни
- Обидва блоки приведено до `location /img/ { alias /home/deploy/www/{env}/uploads/; }` — тепер `/img/book/x.jpg` мапиться в `uploads/book/x.jpg`, як і пише бекенд.
- `try_files $uri =404` (без `$uri/` — директорії роздавати не треба).

## Стан на VPS
Живий конфіг уже частково правили руками (шлях `deploy`, але з зайвим `img/`), через що файли розповзлися по `uploads/img/book/` (легасі) та `uploads/book/` (актуальна). На сервері файли об'єднано в `uploads/book/`, а `uploads/img/book` замінено симлінком → `../book`, тож картинки вже працюють з поточним конфігом. Після застосування цього конфігу (`sudo nginx -t && sudo systemctl reload nginx`) симлінк стане непотрібним.