### PR TITLE
[TFB-155] - set SPRING_JPA_HIBERNATE_DDL_AUTO=none in dev compose, schema is Liquibase-managed

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,8 @@ services:
       - DB_URL=jdbc:postgresql://db:5432/${DB_NAME}
       - DB_USERNAME=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
-      - SPRING_JPA_HIBERNATE_DDL_AUTO=update
+      # Schema is managed by Liquibase; Hibernate must never alter it.
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=none
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRATION=${JWT_EXPIRATION}
       - CLIENT_URL=${CLIENT_URL}


### PR DESCRIPTION
## Проблема
У `docker-compose.dev.yml` стояло `SPRING_JPA_HIBERNATE_DDL_AUTO=update`. Env-змінна **перекриває** налаштування профілю, тож попри `ddl-auto: none` у всіх `application-*.yaml`, на dev Hibernate фактично працював у режимі `update` і міг змінювати схему в обхід Liquibase. Це прибиралося раніше і повернулось регресією в `06f45ab` (Update dev docker-compose config).

## Зміни
- `SPRING_JPA_HIBERNATE_DDL_AUTO=update` → `none` + коментар, що схема керується виключно Liquibase.

## Перевірка
Повні схеми dev- і prod-БД порівняно (усі таблиці/колонки/типи через `information_schema.columns`) — **ідентичні**, дрейфу від `update`-режиму немає, окремі корегувальні міграції не потрібні. Прод-compose цієї змінної не містить.

## Шлях у main
Після мержа в `dev` зміна поїде в `main` через уже відкритий промоушн-PR dev → main: #144 (він автоматично підхопить цей коміт).