### PR TITLE
TFB-142 - fix host nginx img alias paths and update dev docker compose

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -40,9 +40,11 @@ server {
     }
 
     # ОБРОБКА ЗОБРАЖЕНЬ (PROD)
+    # Бекенд пише файли в ${UPLOADS_DIR}/<entity>/<hash>.<ext>,
+    # тому /img/book/x.jpg має мапитись у .../uploads/book/x.jpg
     location /img/ {
-        alias /home/devuser/www/prod/uploads/img/;
-        try_files $uri $uri/ =404;
+        alias /home/deploy/www/prod/uploads/;
+        try_files $uri =404;
         access_log off;
         expires 30d;
         add_header Cache-Control "public";
@@ -67,11 +69,12 @@ server {
         proxy_set_header Host $host;
     }
 
-    location /img/book/ {
-        alias /home/devuser/www/dev/uploads/;
-        try_files $uri $uri/ =404;
+    location /img/ {
+        alias /home/deploy/www/dev/uploads/;
+        try_files $uri =404;
         access_log off;
         expires 30d;
+        add_header Cache-Control "public";
     }
 }
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - ./.env:/app/.env
       # Використовуємо абсолютний шлях для монтування папки з фото
-      - /home/devuser/www/dev/uploads:/app/uploads
+      - ${UPLOADS_DIR}:/app/uploads
     depends_on:
       - db
 
@@ -40,7 +40,7 @@ services:
       - "127.0.0.1:${FE_PORT}:80"
     volumes:
       # Монтуємо ту саму папку, щоб Nginx бачив завантажені фото
-      - /home/devuser/www/dev/uploads:/usr/share/nginx/html/uploads:ro
+      - ${UPLOADS_DIR}:/usr/share/nginx/html/uploads:ro
     depends_on:
       - backend
 


### PR DESCRIPTION
Причина

  Комерційний фікс шляхів зображень (TFB-142) було випадково затерто поганим мержем, коли гілку dev мержили в TFF-135:

  1. Коміт 09edf6d [TFB-142] правильно виправив deploy/nginx.conf:
  location /img/ { alias /home/deploy/www/dev/uploads/; } — так /img/book/x.jpg коректно мапиться на uploads/book/x.jpg (саме туди бекенд реально пише файли, я перевірив ImageServiceImpl/ImageLocalStorageRepositoryImpl).
  2. Коміт злиття 836c632 ("Merge branch 'dev' ... into TFF-135") відкотив цей файл назад до старої версії: location /img/book/ { alias /home/devuser/www/dev/uploads/; }. Через специфіку nginx alias, такий блок обрізає сегмент
  book/ з URL — файл шукається за неправильним шляхом (без підпапки book/) → 404.
  3. Ця відкочена версія й досі в HEAD (git diff 09edf6d HEAD -- deploy/nginx.conf показує повний ревert), проповзла через мерж-коміти #146 і #144 аж до main.
  4. Додатково: коміт f2cd638 переніс каталог деплою з /home/devuser/www на /home/deploy/www, і docker-compose.yaml (prod) коректно використовує ${UPLOADS_DIR}, але docker-compose.dev.yml досі хардкодить старий, "retired" шлях 
  /home/devuser/www/dev/uploads замість ${UPLOADS_DIR} — не синхронізовано з prod-конфігом.

  Тобто на dev зараз накладаються дві проблеми: зламаний location /img/book/ (обрізає підпапку) і застарілий hardcoded шлях у docker-compose, що ігнорує нову структуру каталогів деплою.

  Хочу виправити обидва файли в репозиторії. Але зверніть увагу: deploy/nginx.conf ніде автоматично не деплоїться CI (deploy.yml його не чіпає) — це, судячи з усього, вручну накопійований конфіг на VPS, тож після мого фіксу в
репо комусь треба буде вручну оновити /etc/nginx/... на сервері й зробити nginx -s reload.

Підсумок

  Причина поломки: мерж-коміт 836c632 (dev → TFF-135) випадково відкотив фікс TFB-142 у deploy/nginx.conf — nginx знову шукав файли за /img/book/ з alias, що обрізав підпапку book/, тому реальні файли (uploads/book/<hash>.jpg)
  не знаходились (404). Паралельно docker-compose.dev.yml так і не перейшов на ${UPLOADS_DIR} після міграції каталогу деплою на /home/deploy/www (коміт f2cd638) — лишався хардкоджений старий, "retired" шлях
  /home/devuser/www/dev/uploads.

  Що виправлено в репо:
  - deploy/nginx.conf — обидва блоки /img/ (prod і dev) знову мають правильний alias .../uploads/; без обрізання підпапки.
  - docker-compose.dev.yml — обидва volume для uploads тепер використовують ${UPLOADS_DIR}, як у prod-конфізі.

  Далі потрібна ваша дія на VPS, бо deploy/nginx.conf не деплоїться автоматично через CI:
  1. Змержити/задеплоїти ці зміни (dev-гілка).
  2. Вручну скопіювати оновлений deploy/nginx.conf у актуальний конфіг host-nginx на сервері (наприклад /etc/nginx/sites-available/...) і виконати nginx -t && nginx -s reload.
  3. Перевірити, чи існує/непорожня папка /home/deploy/www/dev/uploads — якщо старі фото лежали лише в /home/devuser/www/dev/uploads, їх варто перенести (rsync), інакше старі оголошення втратять фото.

  Готовий закомітити ці зміни, якщо підтвердите — і, за потреби, ще одразу перевірю чи не постраждав prod так само.