### PR TITLE
[TFB-142] - fix stale PROD location / in deploy/nginx.conf to match live Docker setup

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -6,11 +6,10 @@ server {
     ssl_certificate /etc/letsencrypt/live/bookamore.alt-web.biz.ua/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/bookamore.alt-web.biz.ua/privkey.pem;
 
-    # РОЗДАЧА ФРОНТЕНДУ (PROD)
+    # РОЗДАЧА ФРОНТЕНДУ (PROD) - фронтенд працює як Docker-контейнер на 127.0.0.1:3432
     location / {
-        root /home/deploy/www/prod/frontend/dist;
-        index index.html;
-        try_files $uri $uri/ /index.html;
+        proxy_pass http://127.0.0.1:3432;
+        proxy_set_header Host $host;
     }
 
     # Проксі для API (запити до бекенду)


### PR DESCRIPTION
 [TFB-142] - fix stale PROD location / in deploy/nginx.conf to match live Docker setup

 ## Summary
  - `deploy/nginx.conf` тримав для PROD `location /` статичний `root /home/deploy/www/prod/frontend/dist`, якого на VPS ніколи не існувало (фронтенд збирається лише всередині Docker-образу).
  - Реально прод-фронтенд працює як контейнер `bookamore-prod-frontend-1`, доступний на `127.0.0.1:3432` — конфіг у репо це не відображав. 
  - Замінив блок на `proxy_pass http://127.0.0.1:3432` + `proxy_set_header Host $host`, за аналогією з DEV-блоком, який уже так налаштований.
  
  ## Test plan
  - [x] Звірив diff репо-версії з живим `/etc/nginx/sites-available/bookamore.conf` на VPS — блок тепер функціонально ідентичний.
  - [x] `sudo nginx -t` на VPS пройшов раніше (сам конфіг уже застосований на сервері окремим ручним патчем /img/-блоків; ця зміна синхронізує репозиторій із тим, що вже живе на проді).
  - [x] `curl -sI https://bookamore.alt-web.biz.ua/` — сайт віддає 200 через живий конфіг (не змінювався цим PR, лише репо синхронізовано).


Repo tracked a static root .../frontend/dist that never existed on the VPS; production frontend actually runs as a Docker container proxied on 127.0.0.1:3432.